### PR TITLE
Add input validation and tests for joke generator

### DIFF
--- a/joke_generator.py
+++ b/joke_generator.py
@@ -24,10 +24,20 @@ def generate_code_joke(keywords):
 
 
 def main():
-    raw = input("Inserisci 2-3 parole chiave separate da virgola: ")
-    keywords = [w.strip() for w in raw.split(',') if w.strip()]
-    mode = input("Modalità (normale/codice): ").strip().lower()
-    if mode.startswith('c'):
+    while True:
+        raw = input("Inserisci 2-3 parole chiave separate da virgola: ")
+        keywords = [w.strip() for w in raw.split(',') if w.strip()]
+        if len(keywords) >= 2:
+            break
+        print("Per favore inserisci almeno due parole chiave.")
+
+    while True:
+        mode = input("Modalità (normale/codice): ").strip().lower()
+        if mode in {"normale", "codice"}:
+            break
+        print("Modalità non valida. Inserisci 'normale' o 'codice'.")
+
+    if mode == "codice":
         print(generate_code_joke(keywords))
     else:
         print(generate_joke(keywords))

--- a/test_joke_generator.py
+++ b/test_joke_generator.py
@@ -12,3 +12,21 @@ def test_code_joke_format():
     for w in words:
         assert w in code
     assert "if" in code and "print" in code
+
+
+def test_main_invalid_keywords(monkeypatch, capsys):
+    inputs = iter(["pizza", "pizza,gatto", "normale"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    jg.main()
+    captured = capsys.readouterr().out
+    assert "Per favore inserisci almeno due parole chiave." in captured
+    assert "pizza" in captured and "gatto" in captured
+
+
+def test_main_invalid_mode(monkeypatch, capsys):
+    inputs = iter(["pizza,gatto", "pippo", "codice"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    jg.main()
+    captured = capsys.readouterr().out
+    assert "Modalità non valida" in captured
+    assert "if" in captured


### PR DESCRIPTION
## Summary
- Validate keyword input requiring at least two entries and reprompt when invalid
- Enforce explicit mode selection between `normale` and `codice` with retry on invalid choice
- Extend tests to cover invalid keyword and mode inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7013c563c8330a4d691237ef0f737