### PR TITLE
Add CLI argument parsing and update tests

### DIFF
--- a/joke_generator.py
+++ b/joke_generator.py
@@ -1,3 +1,4 @@
+import argparse
 import random
 
 def generate_joke(keywords):
@@ -23,10 +24,24 @@ def generate_code_joke(keywords):
     )
 
 
-def main():
-    raw = input("Inserisci 2-3 parole chiave separate da virgola: ")
-    keywords = [w.strip() for w in raw.split(',') if w.strip()]
-    mode = input("Modalità (normale/codice): ").strip().lower()
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Generatore di barzellette")
+    parser.add_argument("--keywords", nargs="+", help="Parole chiave per la barzelletta")
+    parser.add_argument("--mode", choices=["normale", "codice"], help="Modalità della barzelletta")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    keywords = args.keywords
+    if not keywords:
+        raw = input("Inserisci 2-3 parole chiave separate da virgola: ")
+        keywords = [w.strip() for w in raw.split(',') if w.strip()]
+    mode = args.mode
+    if not mode:
+        mode = input("Modalità (normale/codice): ").strip().lower()
+    else:
+        mode = mode.lower()
     if mode.startswith('c'):
         print(generate_code_joke(keywords))
     else:

--- a/test_joke_generator.py
+++ b/test_joke_generator.py
@@ -12,3 +12,24 @@ def test_code_joke_format():
     for w in words:
         assert w in code
     assert "if" in code and "print" in code
+
+
+def test_parse_args():
+    args = jg.parse_args(["--keywords", "pizza", "gatto", "banca", "--mode", "codice"])
+    assert args.keywords == ["pizza", "gatto", "banca"]
+    assert args.mode == "codice"
+
+
+def test_main_uses_args(capsys, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: (_ for _ in ()).throw(AssertionError("input should not be called")))
+    jg.main(["--keywords", "pizza", "gatto", "banca", "--mode", "codice"])
+    out = capsys.readouterr().out
+    assert "if" in out and "pizza" in out
+
+
+def test_main_fallback(monkeypatch, capsys):
+    inputs = iter(["pizza, gatto, banca", "codice"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    jg.main([])
+    out = capsys.readouterr().out
+    assert "if" in out and "pizza" in out


### PR DESCRIPTION
## Summary
- Support command-line arguments for keywords and mode in `joke_generator` with fallback to interactive prompts.
- Add parser function and adjust main to respect parsed arguments.
- Expand test coverage for argument parsing and CLI behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7013b2e448330803703adc2b2d738